### PR TITLE
Add overlay enable toggle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,10 +2,12 @@ export interface OverlayConfig {
   duration: number;
   opacity: number;
   font: string;
+  enabled: boolean;
 }
 
 export const overlayConfig: OverlayConfig = {
   duration: 500,
   opacity: 0.8,
-  font: 'Arial'
+  font: 'Arial',
+  enabled: true
 };

--- a/src/keyListener.ts
+++ b/src/keyListener.ts
@@ -2,6 +2,7 @@ import { UiohookKey, uIOhook } from 'uiohook-napi';
 import { showOverlay } from './overlayWindow';
 
 let capsLockState = false;
+let listening = false;
 
 const KEY_MAP: Record<number, string | ((isMac: boolean) => string)> = {
   [UiohookKey.Shift]: 'SHIFT L',
@@ -15,6 +16,8 @@ const KEY_MAP: Record<number, string | ((isMac: boolean) => string)> = {
 };
 
 export const startKeyListener = (): void => {
+  if (listening) return;
+
   uIOhook.on('keydown', (e) => {
     if (e.keycode === UiohookKey.CapsLock) {
       capsLockState = !capsLockState;
@@ -32,8 +35,12 @@ export const startKeyListener = (): void => {
   });
 
   uIOhook.start();
+  listening = true;
 };
 
 export const stopKeyListener = (): void => {
+  if (!listening) return;
   uIOhook.stop();
+  uIOhook.removeAllListeners('keydown');
+  listening = false;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,14 @@ import { app, BrowserWindow } from 'electron';
 import { createOverlayWindow } from './overlayWindow';
 import { createTray } from './tray';
 import { startKeyListener, stopKeyListener } from './keyListener';
+import { overlayConfig } from './config';
 
 app.whenReady().then(() => {
   createOverlayWindow();
   createTray();
-  startKeyListener();
+  if (overlayConfig.enabled) {
+    startKeyListener();
+  }
 
   app.on('window-all-closed', () => {
     // Prevent app from quitting when all windows are closed

--- a/src/overlayWindow.ts
+++ b/src/overlayWindow.ts
@@ -56,3 +56,12 @@ export const showOverlay = (key: string): void => {
     }
   }, overlayConfig.duration);
 };
+
+export const hideOverlay = (): void => {
+  if (!overlayWindow) return;
+  if (hideTimeout) {
+    clearTimeout(hideTimeout);
+    hideTimeout = null;
+  }
+  overlayWindow.hide();
+};

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,5 +1,7 @@
 import { Tray, Menu, nativeImage, app } from 'electron';
 import { overlayConfig } from './config';
+import { startKeyListener, stopKeyListener } from './keyListener';
+import { hideOverlay } from './overlayWindow';
 
 let tray: Tray | null = null;
 
@@ -39,6 +41,21 @@ const updateTrayMenu = (): void => {
         { label: 'Roboto', type: 'radio', checked: overlayConfig.font === 'Roboto', click: () => { overlayConfig.font = 'Roboto'; updateTrayMenu(); } },
         { label: 'San Francisco', type: 'radio', checked: overlayConfig.font === '-apple-system', click: () => { overlayConfig.font = '-apple-system'; updateTrayMenu(); } }
       ]
+    },
+    {
+      label: 'Enabled',
+      type: 'checkbox',
+      checked: overlayConfig.enabled,
+      click: (menuItem) => {
+        overlayConfig.enabled = menuItem.checked;
+        if (overlayConfig.enabled) {
+          startKeyListener();
+        } else {
+          stopKeyListener();
+          hideOverlay();
+        }
+        updateTrayMenu();
+      }
     },
     { type: 'separator' },
     { label: 'Quit', click: () => { app.quit(); } }


### PR DESCRIPTION
## Summary
- allow toggling overlay on/off from tray
- keep overlay state in config
- prevent multiple key listeners and expose hideOverlay helper

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dc35daff48320a5f0914e32769af1