### PR TITLE
Add overlay size and position options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ O objetivo é fornecer uma indicação visual que ajuda em demonstrações, grav
 ## Recursos
 
 - Overlay simples exibindo a tecla modificadora pressionada.
-- Configuração de duração, opacidade e fonte diretamente no menu da bandeja do sistema.
+- Configuração de duração, opacidade, fonte, tamanho e posição diretamente no menu da bandeja do sistema.
 - Suporte a Windows, macOS e Linux.
 
 ## Requisitos

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,6 @@ export const overlayConfig: OverlayConfig = {
   font: 'Arial',
   width: 250,
   height: 80,
-  position: 'center'
+  position: 'center',
   enabled: true
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,24 @@
+export type OverlayPosition =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'center';
+
 export interface OverlayConfig {
   duration: number;
   opacity: number;
   font: string;
+  width: number;
+  height: number;
+  position: OverlayPosition;
 }
 
 export const overlayConfig: OverlayConfig = {
   duration: 500,
   opacity: 0.8,
-  font: 'Arial'
+  font: 'Arial',
+  width: 250,
+  height: 80,
+  position: 'center'
 };

--- a/src/overlayWindow.ts
+++ b/src/overlayWindow.ts
@@ -5,15 +5,35 @@ import { overlayConfig } from './config';
 let overlayWindow: BrowserWindow | null = null;
 let hideTimeout: NodeJS.Timeout | null = null;
 
+const calculatePosition = (displayWidth: number, displayHeight: number): { x: number; y: number } => {
+  switch (overlayConfig.position) {
+    case 'top-left':
+      return { x: 0, y: 0 };
+    case 'top-right':
+      return { x: displayWidth - overlayConfig.width, y: 0 };
+    case 'bottom-left':
+      return { x: 0, y: displayHeight - overlayConfig.height };
+    case 'bottom-right':
+      return { x: displayWidth - overlayConfig.width, y: displayHeight - overlayConfig.height };
+    case 'center':
+    default:
+      return {
+        x: Math.floor(displayWidth / 2 - overlayConfig.width / 2),
+        y: Math.floor(displayHeight / 2 - overlayConfig.height / 2)
+      };
+  }
+};
+
 export const createOverlayWindow = (): void => {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
+  const { x, y } = calculatePosition(width, height);
 
   overlayWindow = new BrowserWindow({
-    width: 250,
-    height: 80,
-    x: Math.floor(width / 2) - 125,
-    y: Math.floor(height / 2) - 40,
+    width: overlayConfig.width,
+    height: overlayConfig.height,
+    x,
+    y,
     frame: false,
     alwaysOnTop: true,
     transparent: true,
@@ -42,6 +62,13 @@ export const showOverlay = (key: string): void => {
   if (hideTimeout) {
     clearTimeout(hideTimeout);
   }
+
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const { width, height } = primaryDisplay.workAreaSize;
+  const { x, y } = calculatePosition(width, height);
+
+  overlayWindow.setSize(overlayConfig.width, overlayConfig.height);
+  overlayWindow.setPosition(x, y);
 
   overlayWindow.webContents.send('update-key', key);
   overlayWindow.webContents.send('update-style', {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -40,6 +40,24 @@ const updateTrayMenu = (): void => {
         { label: 'San Francisco', type: 'radio', checked: overlayConfig.font === '-apple-system', click: () => { overlayConfig.font = '-apple-system'; updateTrayMenu(); } }
       ]
     },
+    {
+      label: 'Size',
+      submenu: [
+        { label: 'Small', type: 'radio', checked: overlayConfig.width === 200 && overlayConfig.height === 60, click: () => { overlayConfig.width = 200; overlayConfig.height = 60; updateTrayMenu(); } },
+        { label: 'Medium', type: 'radio', checked: overlayConfig.width === 250 && overlayConfig.height === 80, click: () => { overlayConfig.width = 250; overlayConfig.height = 80; updateTrayMenu(); } },
+        { label: 'Large', type: 'radio', checked: overlayConfig.width === 300 && overlayConfig.height === 100, click: () => { overlayConfig.width = 300; overlayConfig.height = 100; updateTrayMenu(); } }
+      ]
+    },
+    {
+      label: 'Position',
+      submenu: [
+        { label: 'Top Left', type: 'radio', checked: overlayConfig.position === 'top-left', click: () => { overlayConfig.position = 'top-left'; updateTrayMenu(); } },
+        { label: 'Top Right', type: 'radio', checked: overlayConfig.position === 'top-right', click: () => { overlayConfig.position = 'top-right'; updateTrayMenu(); } },
+        { label: 'Bottom Left', type: 'radio', checked: overlayConfig.position === 'bottom-left', click: () => { overlayConfig.position = 'bottom-left'; updateTrayMenu(); } },
+        { label: 'Bottom Right', type: 'radio', checked: overlayConfig.position === 'bottom-right', click: () => { overlayConfig.position = 'bottom-right'; updateTrayMenu(); } },
+        { label: 'Center', type: 'radio', checked: overlayConfig.position === 'center', click: () => { overlayConfig.position = 'center'; updateTrayMenu(); } }
+      ]
+    },
     { type: 'separator' },
     { label: 'Quit', click: () => { app.quit(); } }
   ]);

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -59,6 +59,8 @@ const updateTrayMenu = (): void => {
         { label: 'Bottom Right', type: 'radio', checked: overlayConfig.position === 'bottom-right', click: () => { overlayConfig.position = 'bottom-right'; updateTrayMenu(); } },
         { label: 'Center', type: 'radio', checked: overlayConfig.position === 'center', click: () => { overlayConfig.position = 'center'; updateTrayMenu(); } }
       ]
+    },
+    {
       label: 'Enabled',
       type: 'checkbox',
       checked: overlayConfig.enabled,


### PR DESCRIPTION
## Summary
- allow customizing overlay position and size via config
- update overlay window to reposition/resize dynamically
- update tray menu to expose size and position choices
- document new features in README

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dc37ba6a88320980de9725a37a43e