### PR TITLE
Implement persistent overlay settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ O objetivo é fornecer uma indicação visual que ajuda em demonstrações, grav
 
 - Overlay simples exibindo a tecla modificadora pressionada.
 - Configuração de duração, opacidade, fonte, tamanho e posição diretamente no menu da bandeja do sistema.
+- As preferências escolhidas são salvas automaticamente e restauradas ao abrir o aplicativo.
+- Opção no menu para restaurar as configurações padrão.
 - Suporte a Windows, macOS e Linux.
 
 ## Requisitos
@@ -49,6 +51,10 @@ Isso realiza o build do TypeScript e em seguida abre o Electron. É possível ex
 ```bash
 npm run dev
 ```
+
+As preferências são armazenadas em um arquivo `overlay-config.json` dentro da
+pasta de dados do usuário. Esse arquivo é carregado automaticamente na próxima
+execução.
 
 ## Build
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,10 +41,13 @@ const ensureConfigPath = () => {
 };
 
 export const loadConfig = (): void => {
+  const file = ensureConfigPath();
+  if (!fs.existsSync(file)) {
+    return;
+  }
   try {
-    const file = ensureConfigPath();
-    if (fs.existsSync(file)) {
-      const data = fs.readFileSync(file, 'utf-8');
+    const data = fs.readFileSync(file, 'utf-8').trim();
+    if (data) {
       const parsed = JSON.parse(data) as Partial<OverlayConfig>;
       Object.assign(overlayConfig, defaultOverlayConfig, parsed);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,13 @@ const ensureConfigPath = () => {
   if (!configPath) {
     configPath = path.join(app.getPath('userData'), 'overlay-config.json');
   }
+  // guarantee directory exists
+  const dir = path.dirname(configPath);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    console.error('Failed creating config directory:', err);
+  }
   return configPath;
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export interface OverlayConfig {
   enabled: boolean;
 }
 
-export const overlayConfig: OverlayConfig = {
+export const defaultOverlayConfig: OverlayConfig = {
   duration: 500,
   opacity: 0.8,
   font: 'Arial',
@@ -23,4 +23,46 @@ export const overlayConfig: OverlayConfig = {
   height: 80,
   position: 'center',
   enabled: true
+};
+
+export const overlayConfig: OverlayConfig = { ...defaultOverlayConfig };
+
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+
+let configPath: string | null = null;
+
+const ensureConfigPath = () => {
+  if (!configPath) {
+    configPath = path.join(app.getPath('userData'), 'overlay-config.json');
+  }
+  return configPath;
+};
+
+export const loadConfig = (): void => {
+  try {
+    const file = ensureConfigPath();
+    if (fs.existsSync(file)) {
+      const data = fs.readFileSync(file, 'utf-8');
+      const parsed = JSON.parse(data) as Partial<OverlayConfig>;
+      Object.assign(overlayConfig, defaultOverlayConfig, parsed);
+    }
+  } catch (err) {
+    console.error('Failed to load config:', err);
+  }
+};
+
+export const saveConfig = (): void => {
+  try {
+    const file = ensureConfigPath();
+    fs.writeFileSync(file, JSON.stringify(overlayConfig, null, 2));
+  } catch (err) {
+    console.error('Failed to save config:', err);
+  }
+};
+
+export const resetConfig = (): void => {
+  Object.assign(overlayConfig, defaultOverlayConfig);
+  saveConfig();
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,10 @@ import { app, BrowserWindow } from 'electron';
 import { createOverlayWindow } from './overlayWindow';
 import { createTray } from './tray';
 import { startKeyListener, stopKeyListener } from './keyListener';
-import { overlayConfig } from './config';
+import { overlayConfig, loadConfig, saveConfig } from './config';
 
 app.whenReady().then(() => {
+  loadConfig();
   createOverlayWindow();
   createTray();
   if (overlayConfig.enabled) {
@@ -18,6 +19,7 @@ app.whenReady().then(() => {
 
 app.on('before-quit', () => {
   stopKeyListener();
+  saveConfig();
 });
 
 app.on('activate', () => {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,5 +1,5 @@
 import { Tray, Menu, nativeImage, app } from 'electron';
-import { overlayConfig } from './config';
+import { overlayConfig, saveConfig, resetConfig } from './config';
 import { startKeyListener, stopKeyListener } from './keyListener';
 import { hideOverlay } from './overlayWindow';
 
@@ -14,58 +14,73 @@ const updateTrayMenu = (): void => {
     {
       label: 'Duration',
       submenu: [
-        { label: '0.25 seconds', type: 'radio', checked: overlayConfig.duration === 250, click: () => { overlayConfig.duration = 250; updateTrayMenu(); } },
-        { label: '0.5 seconds', type: 'radio', checked: overlayConfig.duration === 500, click: () => { overlayConfig.duration = 500; updateTrayMenu(); } },
-        { label: '1 second', type: 'radio', checked: overlayConfig.duration === 1000, click: () => { overlayConfig.duration = 1000; updateTrayMenu(); } },
-        { label: '2 seconds', type: 'radio', checked: overlayConfig.duration === 2000, click: () => { overlayConfig.duration = 2000; updateTrayMenu(); } }
+        { label: '0.25 seconds', type: 'radio', checked: overlayConfig.duration === 250, click: () => { overlayConfig.duration = 250; saveConfig(); updateTrayMenu(); } },
+        { label: '0.5 seconds', type: 'radio', checked: overlayConfig.duration === 500, click: () => { overlayConfig.duration = 500; saveConfig(); updateTrayMenu(); } },
+        { label: '1 second', type: 'radio', checked: overlayConfig.duration === 1000, click: () => { overlayConfig.duration = 1000; saveConfig(); updateTrayMenu(); } },
+        { label: '2 seconds', type: 'radio', checked: overlayConfig.duration === 2000, click: () => { overlayConfig.duration = 2000; saveConfig(); updateTrayMenu(); } }
       ]
     },
     {
       label: 'Opacity',
       submenu: [
-        { label: '25%', type: 'radio', checked: overlayConfig.opacity === 0.25, click: () => { overlayConfig.opacity = 0.25; updateTrayMenu(); } },
-        { label: '50%', type: 'radio', checked: overlayConfig.opacity === 0.5, click: () => { overlayConfig.opacity = 0.5; updateTrayMenu(); } },
-        { label: '75%', type: 'radio', checked: overlayConfig.opacity === 0.75, click: () => { overlayConfig.opacity = 0.75; updateTrayMenu(); } },
-        { label: '80%', type: 'radio', checked: overlayConfig.opacity === 0.8, click: () => { overlayConfig.opacity = 0.8; updateTrayMenu(); } },
-        { label: '90%', type: 'radio', checked: overlayConfig.opacity === 0.9, click: () => { overlayConfig.opacity = 0.9; updateTrayMenu(); } },
-        { label: '100%', type: 'radio', checked: overlayConfig.opacity === 1.0, click: () => { overlayConfig.opacity = 1.0; updateTrayMenu(); } }
+        { label: '25%', type: 'radio', checked: overlayConfig.opacity === 0.25, click: () => { overlayConfig.opacity = 0.25; saveConfig(); updateTrayMenu(); } },
+        { label: '50%', type: 'radio', checked: overlayConfig.opacity === 0.5, click: () => { overlayConfig.opacity = 0.5; saveConfig(); updateTrayMenu(); } },
+        { label: '75%', type: 'radio', checked: overlayConfig.opacity === 0.75, click: () => { overlayConfig.opacity = 0.75; saveConfig(); updateTrayMenu(); } },
+        { label: '80%', type: 'radio', checked: overlayConfig.opacity === 0.8, click: () => { overlayConfig.opacity = 0.8; saveConfig(); updateTrayMenu(); } },
+        { label: '90%', type: 'radio', checked: overlayConfig.opacity === 0.9, click: () => { overlayConfig.opacity = 0.9; saveConfig(); updateTrayMenu(); } },
+        { label: '100%', type: 'radio', checked: overlayConfig.opacity === 1.0, click: () => { overlayConfig.opacity = 1.0; saveConfig(); updateTrayMenu(); } }
       ]
     },
     {
       label: 'Font',
       submenu: [
-        { label: 'Arial', type: 'radio', checked: overlayConfig.font === 'Arial', click: () => { overlayConfig.font = 'Arial'; updateTrayMenu(); } },
-        { label: 'Helvetica', type: 'radio', checked: overlayConfig.font === 'Helvetica', click: () => { overlayConfig.font = 'Helvetica'; updateTrayMenu(); } },
-        { label: 'Times New Roman', type: 'radio', checked: overlayConfig.font === 'Times New Roman', click: () => { overlayConfig.font = 'Times New Roman'; updateTrayMenu(); } },
-        { label: 'Courier New', type: 'radio', checked: overlayConfig.font === 'Courier New', click: () => { overlayConfig.font = 'Courier New'; updateTrayMenu(); } },
-        { label: 'Roboto', type: 'radio', checked: overlayConfig.font === 'Roboto', click: () => { overlayConfig.font = 'Roboto'; updateTrayMenu(); } },
-        { label: 'San Francisco', type: 'radio', checked: overlayConfig.font === '-apple-system', click: () => { overlayConfig.font = '-apple-system'; updateTrayMenu(); } }
+        { label: 'Arial', type: 'radio', checked: overlayConfig.font === 'Arial', click: () => { overlayConfig.font = 'Arial'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Helvetica', type: 'radio', checked: overlayConfig.font === 'Helvetica', click: () => { overlayConfig.font = 'Helvetica'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Times New Roman', type: 'radio', checked: overlayConfig.font === 'Times New Roman', click: () => { overlayConfig.font = 'Times New Roman'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Courier New', type: 'radio', checked: overlayConfig.font === 'Courier New', click: () => { overlayConfig.font = 'Courier New'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Roboto', type: 'radio', checked: overlayConfig.font === 'Roboto', click: () => { overlayConfig.font = 'Roboto'; saveConfig(); updateTrayMenu(); } },
+        { label: 'San Francisco', type: 'radio', checked: overlayConfig.font === '-apple-system', click: () => { overlayConfig.font = '-apple-system'; saveConfig(); updateTrayMenu(); } }
       ]
     },
     {
       label: 'Size',
       submenu: [
-        { label: 'Small', type: 'radio', checked: overlayConfig.width === 200 && overlayConfig.height === 60, click: () => { overlayConfig.width = 200; overlayConfig.height = 60; updateTrayMenu(); } },
-        { label: 'Medium', type: 'radio', checked: overlayConfig.width === 250 && overlayConfig.height === 80, click: () => { overlayConfig.width = 250; overlayConfig.height = 80; updateTrayMenu(); } },
-        { label: 'Large', type: 'radio', checked: overlayConfig.width === 300 && overlayConfig.height === 100, click: () => { overlayConfig.width = 300; overlayConfig.height = 100; updateTrayMenu(); } }
+        { label: 'Small', type: 'radio', checked: overlayConfig.width === 200 && overlayConfig.height === 60, click: () => { overlayConfig.width = 200; overlayConfig.height = 60; saveConfig(); updateTrayMenu(); } },
+        { label: 'Medium', type: 'radio', checked: overlayConfig.width === 250 && overlayConfig.height === 80, click: () => { overlayConfig.width = 250; overlayConfig.height = 80; saveConfig(); updateTrayMenu(); } },
+        { label: 'Large', type: 'radio', checked: overlayConfig.width === 300 && overlayConfig.height === 100, click: () => { overlayConfig.width = 300; overlayConfig.height = 100; saveConfig(); updateTrayMenu(); } }
       ]
     },
     {
       label: 'Position',
       submenu: [
-        { label: 'Top Left', type: 'radio', checked: overlayConfig.position === 'top-left', click: () => { overlayConfig.position = 'top-left'; updateTrayMenu(); } },
-        { label: 'Top Right', type: 'radio', checked: overlayConfig.position === 'top-right', click: () => { overlayConfig.position = 'top-right'; updateTrayMenu(); } },
-        { label: 'Bottom Left', type: 'radio', checked: overlayConfig.position === 'bottom-left', click: () => { overlayConfig.position = 'bottom-left'; updateTrayMenu(); } },
-        { label: 'Bottom Right', type: 'radio', checked: overlayConfig.position === 'bottom-right', click: () => { overlayConfig.position = 'bottom-right'; updateTrayMenu(); } },
-        { label: 'Center', type: 'radio', checked: overlayConfig.position === 'center', click: () => { overlayConfig.position = 'center'; updateTrayMenu(); } }
+        { label: 'Top Left', type: 'radio', checked: overlayConfig.position === 'top-left', click: () => { overlayConfig.position = 'top-left'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Top Right', type: 'radio', checked: overlayConfig.position === 'top-right', click: () => { overlayConfig.position = 'top-right'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Bottom Left', type: 'radio', checked: overlayConfig.position === 'bottom-left', click: () => { overlayConfig.position = 'bottom-left'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Bottom Right', type: 'radio', checked: overlayConfig.position === 'bottom-right', click: () => { overlayConfig.position = 'bottom-right'; saveConfig(); updateTrayMenu(); } },
+        { label: 'Center', type: 'radio', checked: overlayConfig.position === 'center', click: () => { overlayConfig.position = 'center'; saveConfig(); updateTrayMenu(); } }
       ]
     },
     {
       label: 'Enabled',
       type: 'checkbox',
       checked: overlayConfig.enabled,
-      click: (menuItem) => {
-        overlayConfig.enabled = menuItem.checked;
+        click: (menuItem) => {
+          overlayConfig.enabled = menuItem.checked;
+          if (overlayConfig.enabled) {
+            startKeyListener();
+          } else {
+            stopKeyListener();
+            hideOverlay();
+          }
+          saveConfig();
+          updateTrayMenu();
+        }
+    },
+    { type: 'separator' },
+    {
+      label: 'Reset Settings',
+      click: () => {
+        resetConfig();
         if (overlayConfig.enabled) {
           startKeyListener();
         } else {


### PR DESCRIPTION
## Summary
- persist user-configured settings to overlay-config.json
- load saved settings on startup
- add reset settings option to tray menu
- document settings persistence in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dcda3ca8c8320a00d58e5eb377326