### PR TITLE
Fix packaging workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build and package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-build
+          path: dist/**
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ Para apenas gerar os arquivos JavaScript em `dist/` (sem iniciar o Electron):
 npm run build
 ```
 
-Atualmente não há configuração para empacotar o aplicativo em instaladores. Caso deseje distribuir, você pode utilizar ferramentas como [electron-builder](https://www.electron.build/) ou [electron-forge](https://www.electronforge.io/) adicionando as configurações necessárias.
+Para gerar instaladores para o sistema operacional atual execute:
+
+```bash
+npm run dist
+```
+
+Esse comando utiliza o **electron-builder**. O repositório inclui um fluxo de GitHub Actions que roda automaticamente o `electron-builder` sempre que um merge é realizado na branch `main`, publicando os artefatos gerados para cada sistema operacional.
 
 ## Estrutura do Projeto
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "tsc",
     "start": "npm run build && electron .",
     "dev": "npm run build && electron . --dev",
+    "dist": "npm run build && electron-builder",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -16,9 +17,21 @@
     "@types/node": "^24.0.1",
     "electron": "^36.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "electron-builder": "^24.9.1"
   },
   "dependencies": {
     "uiohook-napi": "^1.5.4"
+  },
+  "build": {
+    "appId": "com.elecapp.modkeys",
+    "files": [
+      "dist/**/*",
+      "overlay.html"
+    ],
+    "asar": true,
+    "mac": {
+      "target": ["zip"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- update packaging command to rely on host OS
- avoid DMG builds that require dmg-license
- document how to create installers for the current OS

## Testing
- `npm run build`
- `npm run dist` *(fails: electron-builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de9930cf88320954fbe6eee4b43e0